### PR TITLE
aligned feasibility category ids of catalog with 21434 for example IS…

### DIFF
--- a/ISO21434/ISOComposition/models/Catalog.mps
+++ b/ISO21434/ISOComposition/models/Catalog.mps
@@ -111,20 +111,20 @@
       <property role="TrG5h" value="TC.1" />
       <property role="DVXpC" value="Spoofing" />
       <node concept="3RtpOr" id="4CQftq3lQlo" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhx" resolve="Ex0" />
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhx" resolve="SE0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQlp" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="W0" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="WoO0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQlr" role="3RtpOm">
         <ref role="3RtpRB" to="xz8e:4CQftq3lQhL" resolve="Eq0" />
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQls" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhR" resolve="K1" />
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhR" resolve="KoIC1" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
       </node>
       <node concept="3RtnZZ" id="4CQftq3lQlt" role="3Rtpal">
         <ref role="122Z_O" to="xz8e:4CQftq3lQja" resolve="C" />
@@ -134,8 +134,8 @@
       </node>
       <node concept="3h3ntD" id="3JPVaN3cLY3" role="3Rtpag" />
       <node concept="3RtpOr" id="4NcsJzPXm1o" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="T0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="ET0" />
       </node>
       <node concept="3WX1Ss" id="75wqdixoyij" role="3Rtpag" />
       <node concept="3VMn$a" id="7bZZv_jRV18" role="2JHqPs">
@@ -235,8 +235,8 @@
       <property role="DVXpC" value="Identity spoofing when logging in (with a password)" />
       <ref role="323Bpw" node="4CQftq3lQli" resolve="TC.1" />
       <node concept="3RtpOr" id="4CQftq3lQl_" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="Ex1" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="SE1" />
       </node>
       <node concept="3RtnZZ" id="4CQftq3lQlE" role="3Rtpal">
         <ref role="122Z_O" to="xz8e:4CQftq3lQja" resolve="C" />
@@ -253,8 +253,8 @@
       <property role="DVXpC" value="Resource Location Spoofing" />
       <ref role="323Bpw" node="4CQftq3lQli" resolve="TC.1" />
       <node concept="3RtpOr" id="4CQftq3lQlM" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="Ex1" />
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="SE1" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
       </node>
       <node concept="3RtnZZ" id="4CQftq3lQlR" role="3Rtpal">
         <ref role="122Z_O" to="xz8e:4CQftq3lQja" resolve="C" />
@@ -343,28 +343,28 @@
       <property role="DVXpC" value="Tampering" />
       <node concept="13pXwX" id="4CQftq3lQmM" role="3Rtpag" />
       <node concept="3RtpOr" id="4CQftq3lQmN" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="Ex1" />
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="SE1" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQmO" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="W0" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="WoO0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQmQ" role="3RtpOm">
         <ref role="3RtpRB" to="xz8e:4CQftq3lQhL" resolve="Eq0" />
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQmR" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="K0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="KoIC0" />
       </node>
       <node concept="3RtnZZ" id="4CQftq3lQmS" role="3Rtpal">
         <ref role="122Z_O" to="xz8e:4CQftq3lQjc" resolve="I" />
       </node>
       <node concept="3h3ntD" id="3JPVaN3cLY6" role="3Rtpag" />
       <node concept="3RtpOr" id="4NcsJzPXm2m" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="T0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="ET0" />
       </node>
       <node concept="3WX1Ss" id="75wqdixoyim" role="3Rtpag" />
       <node concept="3VMn$a" id="7bZZv_jRV21" role="2JHqPs">
@@ -408,12 +408,12 @@
       <ref role="323Bpw" node="4CQftq3lQmG" resolve="TC.2" />
       <node concept="13pXwX" id="4CQftq3lQny" role="3Rtpag" />
       <node concept="3RtpOr" id="4CQftq3lQnB" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="Ex2" />
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="SE2" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQnF" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhS" resolve="K2" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhS" resolve="KoIC2" />
       </node>
       <node concept="3RtnZZ" id="4CQftq3lQnG" role="3Rtpal">
         <ref role="122Z_O" to="xz8e:4CQftq3lQjc" resolve="I" />
@@ -490,27 +490,27 @@
       <property role="DVXpC" value="Repudiation" />
       <node concept="3h3ntD" id="6ytiexnPZIS" role="3Rtpag" />
       <node concept="3RtpOr" id="4CQftq3lQpi" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhx" resolve="Ex0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhx" resolve="SE0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQpj" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="W0" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="WoO0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQpl" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
         <ref role="3RtpRB" to="xz8e:4CQftq3lQhL" resolve="Eq0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQpm" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="K0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="KoIC0" />
       </node>
       <node concept="3RtnZZ" id="4CQftq3lQpn" role="3Rtpal">
         <ref role="122Z_O" to="xz8e:4CQftq3lQjc" resolve="I" />
       </node>
       <node concept="3RtpOr" id="4NcsJzPXm30" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="T0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="ET0" />
       </node>
       <node concept="3WX1Ss" id="75wqdixoyio" role="3Rtpag" />
       <node concept="3VMn$a" id="7bZZv_jRV2z" role="2JHqPs">
@@ -526,28 +526,28 @@
       <property role="DVXpC" value="Information Disclosure" />
       <node concept="13pXwX" id="4CQftq3lQpv" role="3Rtpag" />
       <node concept="3RtpOr" id="4CQftq3lQpw" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhx" resolve="Ex0" />
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhx" resolve="SE0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQpx" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="W0" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="WoO0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQpz" role="3RtpOm">
         <ref role="3RtpRB" to="xz8e:4CQftq3lQhL" resolve="Eq0" />
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQp$" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="K0" />
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="KoIC0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
       </node>
       <node concept="3RtnZZ" id="4CQftq3lQp_" role="3Rtpal">
         <ref role="122Z_O" to="xz8e:4CQftq3lQja" resolve="C" />
       </node>
       <node concept="3h3ntD" id="3JPVaN3cLY8" role="3Rtpag" />
       <node concept="3RtpOr" id="4NcsJzPXm9n" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="T0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="ET0" />
       </node>
       <node concept="3WX1Ss" id="75wqdixoyip" role="3Rtpag" />
       <node concept="3VMn$a" id="7bZZv_jRV2A" role="2JHqPs">
@@ -650,7 +650,7 @@
       </node>
       <node concept="13pXwX" id="2Wj3TpYBOXQ" role="3Rtpag" />
       <node concept="3RtpOr" id="2Wj3TpYBOXS" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhB" resolve="W1" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhB" resolve="WoO1" />
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
       </node>
       <node concept="3VMn$a" id="7bZZv_jRV32" role="2JHqPs">
@@ -722,16 +722,16 @@
       </node>
       <node concept="13pXwX" id="2Wj3TpYBP5h" role="3Rtpag" />
       <node concept="3RtpOr" id="2Wj3TpYBP5i" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="Ex2" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="SE2" />
       </node>
       <node concept="3RtpOr" id="2Wj3TpYBP5j" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhB" resolve="W1" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhB" resolve="WoO1" />
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
       </node>
       <node concept="3RtpOr" id="2Wj3TpYBP5k" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhH" resolve="T1" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhH" resolve="ET1" />
       </node>
       <node concept="3RtpOr" id="2Wj3TpYBP5l" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
@@ -845,11 +845,11 @@
       <property role="DVXpC" value="Denial of Service" />
       <node concept="13pXwX" id="4CQftq3lQqQ" role="3Rtpag" />
       <node concept="3RtpOr" id="4CQftq3lQqR" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhx" resolve="Ex0" />
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhx" resolve="SE0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQqS" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="W0" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="WoO0" />
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQqU" role="3RtpOm">
@@ -857,16 +857,16 @@
         <ref role="3RtpRB" to="xz8e:4CQftq3lQhL" resolve="Eq0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQqV" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="K0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="KoIC0" />
       </node>
       <node concept="3RtnZZ" id="4CQftq3lQqW" role="3Rtpal">
         <ref role="122Z_O" to="xz8e:4CQftq3lQjb" resolve="A" />
       </node>
       <node concept="3h3ntD" id="3JPVaN3cLYa" role="3Rtpag" />
       <node concept="3RtpOr" id="4NcsJzPXms4" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="T0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="ET0" />
       </node>
       <node concept="3WX1Ss" id="75wqdixnJt7" role="3Rtpag" />
       <node concept="3VMn$a" id="7bZZv_jRV3Q" role="2JHqPs">
@@ -1128,12 +1128,12 @@
       <property role="DVXpC" value="Excessive Allocation of Resources" />
       <ref role="323Bpw" node="4CQftq3lQqK" resolve="TC.5" />
       <node concept="3RtpOr" id="4CQftq3lQsb" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="Ex1" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="SE1" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQsf" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhR" resolve="K1" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhR" resolve="KoIC1" />
       </node>
       <node concept="3RtnZZ" id="4CQftq3lQsg" role="3Rtpal">
         <ref role="122Z_O" to="xz8e:4CQftq3lQjb" resolve="A" />
@@ -1401,20 +1401,20 @@
       <property role="TrG5h" value="TC.6" />
       <property role="DVXpC" value="Elevation of privilege" />
       <node concept="3RtpOr" id="4CQftq3lQsv" role="3RtpOm">
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="Ex1" />
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="SE1" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQsw" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="W0" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="WoO0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQsy" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
         <ref role="3RtpRB" to="xz8e:4CQftq3lQhL" resolve="Eq0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQsz" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhR" resolve="K1" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhR" resolve="KoIC1" />
       </node>
       <node concept="3RtnZZ" id="4CQftq3lQsC" role="3Rtpal">
         <ref role="122Z_O" to="xz8e:4CQftq3lQja" resolve="C" />
@@ -1425,8 +1425,8 @@
       <node concept="13pXwX" id="4CQftq3lQsF" role="3Rtpag" />
       <node concept="3h3ntD" id="3JPVaN3cLYe" role="3Rtpag" />
       <node concept="3RtpOr" id="4NcsJzPXmCi" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="T0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="ET0" />
       </node>
       <node concept="3WX1Ss" id="75wqdixoyiv" role="3Rtpag" />
       <node concept="3VMn$a" id="7bZZv_jRV6q" role="2JHqPs">
@@ -1708,24 +1708,24 @@
       <property role="TrG5h" value="CC.1" />
       <property role="DVXpC" value="Symmetric encryption" />
       <node concept="3RtpOr" id="4CQftq3lQwn" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="Ex1" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhy" resolve="SE1" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQwo" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="W0" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="WoO0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQwp" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="T0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhG" resolve="ET0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQwq" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
         <ref role="3RtpRB" to="xz8e:4CQftq3lQhL" resolve="Eq0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQwr" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="K0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="KoIC0" />
       </node>
       <node concept="13pXwX" id="4CQftq3lQww" role="1u4RdC" />
       <node concept="122ZmF" id="4CQftq3lQwy" role="1u4Rdk">
@@ -1747,12 +1747,12 @@
       <ref role="323Bpw" node="4CQftq3lQwm" resolve="CC.1" />
       <node concept="13pXwX" id="4CQftq3lQwZ" role="1u4RdC" />
       <node concept="3RtpOr" id="4CQftq3lQx1" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="Ex2" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="SE2" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQx3" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:6LOW4IwXsbN" resolve="T4" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:6LOW4IwXsbN" resolve="ET4" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQx4" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
@@ -1782,24 +1782,24 @@
       </node>
       <node concept="3h3ntD" id="1Hnh$uA1dZ" role="1u4RdC" />
       <node concept="3RtpOr" id="1Hnh$uA1e0" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="Ex2" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="SE2" />
       </node>
       <node concept="3RtpOr" id="1Hnh$uA1e1" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="W0" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="WoO0" />
       </node>
       <node concept="3RtpOr" id="1Hnh$uA1e2" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:6LOW4IwXsbN" resolve="T4" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:6LOW4IwXsbN" resolve="ET4" />
       </node>
       <node concept="3RtpOr" id="1Hnh$uA1e3" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
         <ref role="3RtpRB" to="xz8e:4CQftq3lQhO" resolve="Eq3" />
       </node>
       <node concept="3RtpOr" id="1Hnh$uA1e4" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="K0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="KoIC0" />
       </node>
       <node concept="3RtnZZ" id="6ytiexnPZJa" role="1u4RdF">
         <ref role="122Z_O" to="xz8e:4CQftq3lQja" resolve="C" />
@@ -1814,24 +1814,24 @@
       <property role="TrG5h" value="CC.3" />
       <property role="DVXpC" value="Hash function" />
       <node concept="3RtpOr" id="4CQftq3lQtC" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="Ex2" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="SE2" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQtD" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="W0" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhA" resolve="WoO0" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQtE" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:6LOW4IwXsbN" resolve="T4" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:6LOW4IwXsbN" resolve="ET4" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQtF" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
         <ref role="3RtpRB" to="xz8e:4CQftq3lQhO" resolve="Eq3" />
       </node>
       <node concept="3RtpOr" id="4CQftq3lQtG" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="K0" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhQ" resolve="KoIC0" />
       </node>
       <node concept="13pXwX" id="4CQftq3lQtL" role="1u4RdC" />
       <node concept="3h3ntD" id="3JPVaN3cLYh" role="1u4RdC" />
@@ -1842,24 +1842,24 @@
       <property role="TrG5h" value="CC.4" />
       <property role="DVXpC" value="Whitelisting" />
       <node concept="3RtpOr" id="5U29EQHb4lG" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="Ex" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="Ex2" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhw" resolve="SE" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhz" resolve="SE2" />
       </node>
       <node concept="3RtpOr" id="5U29EQHb4lH" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQh_" resolve="W" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhD" resolve="W3" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhD" resolve="WoO3" />
       </node>
       <node concept="3RtpOr" id="5U29EQHb4lI" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="T" />
-        <ref role="3RtpRB" to="xz8e:6LOW4IwXsbT" resolve="T3" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhE" resolve="ET" />
+        <ref role="3RtpRB" to="xz8e:6LOW4IwXsbT" resolve="ET3" />
       </node>
       <node concept="3RtpOr" id="5U29EQHb4lJ" role="3RtpOm">
         <ref role="3RtpOq" to="xz8e:4CQftq3lQhK" resolve="Eq" />
         <ref role="3RtpRB" to="xz8e:4CQftq3lQhM" resolve="Eq1" />
       </node>
       <node concept="3RtpOr" id="5U29EQHb4lK" role="3RtpOm">
-        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="K" />
-        <ref role="3RtpRB" to="xz8e:4CQftq3lQhS" resolve="K2" />
+        <ref role="3RtpOq" to="xz8e:4CQftq3lQhP" resolve="KoIC" />
+        <ref role="3RtpRB" to="xz8e:4CQftq3lQhS" resolve="KoIC2" />
       </node>
       <node concept="13pXwX" id="5U29EQHb4lL" role="1u4RdC" />
       <node concept="3h3ntD" id="5U29EQHb4lM" role="1u4RdC" />

--- a/ISO21434/ISOComposition/models/MethodConfiguration.mps
+++ b/ISO21434/ISOComposition/models/MethodConfiguration.mps
@@ -3656,34 +3656,34 @@
       </node>
     </node>
     <node concept="3Rgae8" id="4CQftq3lQhE" role="3Rgdis">
-      <property role="TrG5h" value="T" />
+      <property role="TrG5h" value="ET" />
       <property role="DVXpC" value="Elapsed time" />
       <node concept="3Rgaek" id="4CQftq3lQhG" role="3RgdiP">
-        <property role="TrG5h" value="T0" />
+        <property role="TrG5h" value="ET0" />
         <property role="3Rgaeq" value="0" />
         <property role="DVXpC" value="≤ 1 day" />
         <node concept="3VMn$a" id="7bZZv_jRVjD" role="2JHqPs" />
       </node>
       <node concept="3Rgaek" id="4CQftq3lQhH" role="3RgdiP">
-        <property role="TrG5h" value="T1" />
+        <property role="TrG5h" value="ET1" />
         <property role="3Rgaeq" value="1" />
         <property role="DVXpC" value="≤ 1 week" />
         <node concept="3VMn$a" id="7bZZv_jRVjE" role="2JHqPs" />
       </node>
       <node concept="3Rgaek" id="4CQftq3lQhI" role="3RgdiP">
-        <property role="TrG5h" value="T2" />
+        <property role="TrG5h" value="ET2" />
         <property role="3Rgaeq" value="4" />
         <property role="DVXpC" value="≤ 1 month" />
         <node concept="3VMn$a" id="7bZZv_jRVjF" role="2JHqPs" />
       </node>
       <node concept="3Rgaek" id="6LOW4IwXsbT" role="3RgdiP">
-        <property role="TrG5h" value="T3" />
+        <property role="TrG5h" value="ET3" />
         <property role="3Rgaeq" value="10" />
         <property role="DVXpC" value="≤ 6 months" />
         <node concept="3VMn$a" id="7bZZv_jRVjG" role="2JHqPs" />
       </node>
       <node concept="3Rgaek" id="6LOW4IwXsbN" role="3RgdiP">
-        <property role="TrG5h" value="T4" />
+        <property role="TrG5h" value="ET4" />
         <property role="3Rgaeq" value="19" />
         <property role="DVXpC" value="&gt; 6 months" />
         <node concept="3VMn$a" id="7bZZv_jRVjH" role="2JHqPs" />
@@ -3796,10 +3796,10 @@
       </node>
     </node>
     <node concept="3Rgae8" id="4CQftq3lQhw" role="3Rgdis">
-      <property role="TrG5h" value="Ex" />
+      <property role="TrG5h" value="SE" />
       <property role="DVXpC" value="Specialist expertise" />
       <node concept="3Rgaek" id="4CQftq3lQhx" role="3RgdiP">
-        <property role="TrG5h" value="Ex0" />
+        <property role="TrG5h" value="SE0" />
         <property role="3Rgaeq" value="0" />
         <property role="DVXpC" value="Layman" />
         <node concept="3VMn$a" id="7bZZv_jRVjv" role="2JHqPs">
@@ -3882,7 +3882,7 @@
         </node>
       </node>
       <node concept="3Rgaek" id="4CQftq3lQhy" role="3RgdiP">
-        <property role="TrG5h" value="Ex1" />
+        <property role="TrG5h" value="SE1" />
         <property role="3Rgaeq" value="3" />
         <property role="DVXpC" value="Proficient" />
         <node concept="3VMn$a" id="7bZZv_jRVjw" role="2JHqPs">
@@ -3992,7 +3992,7 @@
         </node>
       </node>
       <node concept="3Rgaek" id="4CQftq3lQhz" role="3RgdiP">
-        <property role="TrG5h" value="Ex2" />
+        <property role="TrG5h" value="SE2" />
         <property role="3Rgaeq" value="6" />
         <property role="DVXpC" value="Expert" />
         <node concept="3VMn$a" id="7bZZv_jRVjx" role="2JHqPs">
@@ -4144,7 +4144,7 @@
         </node>
       </node>
       <node concept="3Rgaek" id="4CQftq3lQh$" role="3RgdiP">
-        <property role="TrG5h" value="Ex3" />
+        <property role="TrG5h" value="SE3" />
         <property role="3Rgaeq" value="8" />
         <property role="DVXpC" value="Multiple experts" />
         <node concept="3VMn$a" id="7bZZv_jRVjy" role="2JHqPs">
@@ -4334,10 +4334,10 @@
       </node>
     </node>
     <node concept="3Rgae8" id="4CQftq3lQhP" role="3Rgdis">
-      <property role="TrG5h" value="K" />
+      <property role="TrG5h" value="KoIC" />
       <property role="DVXpC" value="Knowledge of the item or component" />
       <node concept="3Rgaek" id="4CQftq3lQhQ" role="3RgdiP">
-        <property role="TrG5h" value="K0" />
+        <property role="TrG5h" value="KoIC0" />
         <property role="3Rgaeq" value="0" />
         <property role="DVXpC" value="Public information" />
         <node concept="3VMn$a" id="7bZZv_jRVjO" role="2JHqPs">
@@ -4429,7 +4429,7 @@
         </node>
       </node>
       <node concept="3Rgaek" id="4CQftq3lQhR" role="3RgdiP">
-        <property role="TrG5h" value="K1" />
+        <property role="TrG5h" value="KoIC1" />
         <property role="3Rgaeq" value="3" />
         <property role="DVXpC" value="Restricted information" />
         <node concept="3VMn$a" id="7bZZv_jRVjP" role="2JHqPs">
@@ -4551,7 +4551,7 @@
         </node>
       </node>
       <node concept="3Rgaek" id="4CQftq3lQhS" role="3RgdiP">
-        <property role="TrG5h" value="K2" />
+        <property role="TrG5h" value="KoIC2" />
         <property role="3Rgaeq" value="7" />
         <property role="DVXpC" value="Confidential information" />
         <node concept="3VMn$a" id="7bZZv_jRVjQ" role="2JHqPs">
@@ -4676,7 +4676,7 @@
         </node>
       </node>
       <node concept="3Rgaek" id="4CQftq3lQhT" role="3RgdiP">
-        <property role="TrG5h" value="K3" />
+        <property role="TrG5h" value="KoIC3" />
         <property role="3Rgaeq" value="11" />
         <property role="DVXpC" value="Strictly confidential information" />
         <node concept="3VMn$a" id="7bZZv_jRVjR" role="2JHqPs">
@@ -4914,7 +4914,7 @@
       <property role="TrG5h" value="W" />
       <property role="DVXpC" value="Window of opportunity" />
       <node concept="3Rgaek" id="4CQftq3lQhA" role="3RgdiP">
-        <property role="TrG5h" value="W0" />
+        <property role="TrG5h" value="WoO0" />
         <property role="3Rgaeq" value="0" />
         <property role="DVXpC" value="Unlimited" />
         <node concept="3VMn$a" id="7bZZv_jRVj$" role="2JHqPs">
@@ -5084,7 +5084,7 @@
         </node>
       </node>
       <node concept="3Rgaek" id="4CQftq3lQhB" role="3RgdiP">
-        <property role="TrG5h" value="W1" />
+        <property role="TrG5h" value="WoO1" />
         <property role="3Rgaeq" value="1" />
         <property role="DVXpC" value="Easy" />
         <node concept="3VMn$a" id="7bZZv_jRVj_" role="2JHqPs">
@@ -5191,7 +5191,7 @@
         </node>
       </node>
       <node concept="3Rgaek" id="4CQftq3lQhC" role="3RgdiP">
-        <property role="TrG5h" value="W2" />
+        <property role="TrG5h" value="WoO2" />
         <property role="3Rgaeq" value="4" />
         <property role="DVXpC" value="Moderate" />
         <node concept="3VMn$a" id="7bZZv_jRVjA" role="2JHqPs">
@@ -5337,7 +5337,7 @@
         </node>
       </node>
       <node concept="3Rgaek" id="4CQftq3lQhD" role="3RgdiP">
-        <property role="TrG5h" value="W3" />
+        <property role="TrG5h" value="WoO3" />
         <property role="3Rgaeq" value="10" />
         <property role="DVXpC" value="Difficult" />
         <node concept="3VMn$a" id="7bZZv_jRVjB" role="2JHqPs">


### PR DESCRIPTION
- What changed

- [ ] The ids of feasibility categories are renamed to ET, SE, KoIC, WoO, Eq. see https://gitlab.com/itemis/yakindu-iot/ysec/-/issues/13

- Open todos

- [ ] review it