### PR TITLE
Prepare examples for RCP release 25.2

### DIFF
--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="95" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -25,7 +25,7 @@
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
-    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
+    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -24,7 +24,7 @@
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
-    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
+    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -25,7 +25,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="95" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -22,7 +22,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="95" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -21,7 +21,7 @@
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
-    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
+    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -24,7 +24,7 @@
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
-    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
+    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -25,7 +25,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="95" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -166,6 +166,7 @@
       <concept id="2129184553237592647" name="com.moraad.reports.structure.ComponentsTableReportItem" flags="ng" index="3xttxm" />
       <concept id="2129184553237592677" name="com.moraad.reports.structure.ChannelsTableReportItem" flags="ng" index="3xttxO" />
       <concept id="2129184553237375058" name="com.moraad.reports.structure.IToeElementTableReportItem" flags="ng" index="3xuwD3">
+        <property id="3907226716665410510" name="excludeHierarchy" index="1xYb8L" />
         <property id="760225772605925982" name="excludeCAL" index="3ZMjsh" />
         <property id="760225772605925988" name="excludeTrustAssessment" index="3ZMjsF" />
       </concept>
@@ -3940,8 +3941,15 @@
     </node>
     <node concept="ymko6" id="1k$QKsQS8zI" role="yp9Ks" />
     <node concept="3xttxO" id="1k$QKsQS93e" role="yp9Ks" />
+    <node concept="3xttxO" id="3oTgvXnUVx9" role="yp9Ks">
+      <property role="1xYb8L" value="true" />
+    </node>
     <node concept="3xttxO" id="7tyS2pKL2qM" role="yp9Ks">
       <property role="3ZMjsh" value="true" />
+    </node>
+    <node concept="3xttxO" id="3oTgvXnUVz9" role="yp9Ks">
+      <property role="3ZMjsh" value="true" />
+      <property role="1xYb8L" value="true" />
     </node>
     <node concept="ymko6" id="1k$QKsQS9zN" role="yp9Ks" />
     <node concept="3y_2Gs" id="1VvRu3aCB92" role="yp9Ks" />
@@ -3965,15 +3973,31 @@
     </node>
     <node concept="ymko6" id="1k$QKsQSa_b" role="yp9Ks" />
     <node concept="3xttxm" id="1k$QKsQSb68" role="yp9Ks" />
+    <node concept="3xttxm" id="3oTgvXnUVlu" role="yp9Ks">
+      <property role="1xYb8L" value="true" />
+    </node>
     <node concept="3xttxm" id="7tyS2pKL2jo" role="yp9Ks">
       <property role="3ZMjsF" value="true" />
+    </node>
+    <node concept="3xttxm" id="3oTgvXnUVno" role="yp9Ks">
+      <property role="3ZMjsF" value="true" />
+      <property role="1xYb8L" value="true" />
     </node>
     <node concept="3xttxm" id="7tyS2pKL2ld" role="yp9Ks">
       <property role="3ZMjsh" value="true" />
     </node>
+    <node concept="3xttxm" id="3oTgvXnUVpj" role="yp9Ks">
+      <property role="3ZMjsh" value="true" />
+      <property role="1xYb8L" value="true" />
+    </node>
     <node concept="3xttxm" id="7tyS2pKL2n3" role="yp9Ks">
       <property role="3ZMjsF" value="true" />
       <property role="3ZMjsh" value="true" />
+    </node>
+    <node concept="3xttxm" id="3oTgvXnUVrf" role="yp9Ks">
+      <property role="3ZMjsF" value="true" />
+      <property role="3ZMjsh" value="true" />
+      <property role="1xYb8L" value="true" />
     </node>
     <node concept="ymko6" id="1k$QKsQSbAD" role="yp9Ks" />
     <node concept="3dmGyN" id="1VvRu3aCBhc" role="yp9Ks" />
@@ -4076,8 +4100,15 @@
     <node concept="3xdgjh" id="1k$QKsQSqY_" role="yp9Ks" />
     <node concept="ymko6" id="1k$QKsQSrun" role="yp9Ks" />
     <node concept="3xuwDp" id="1k$QKsQSs04" role="yp9Ks" />
+    <node concept="3xuwDp" id="3oTgvXnUVtc" role="yp9Ks">
+      <property role="1xYb8L" value="true" />
+    </node>
     <node concept="3xuwDp" id="7tyS2pKL2oU" role="yp9Ks">
       <property role="3ZMjsh" value="true" />
+    </node>
+    <node concept="3xuwDp" id="3oTgvXnUVva" role="yp9Ks">
+      <property role="3ZMjsh" value="true" />
+      <property role="1xYb8L" value="true" />
     </node>
     <node concept="ymko6" id="1k$QKsQSsvK" role="yp9Ks" />
     <node concept="2SZOu" id="1VvRu3aCBw1" role="yp9Ks" />

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -24,7 +24,7 @@
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
-    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
+    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -25,7 +25,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="95" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -22,7 +22,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="95" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -21,7 +21,7 @@
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
-    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
+    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -24,7 +24,7 @@
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
-    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
+    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -25,7 +25,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="95" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -24,7 +24,7 @@
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
-    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
+    <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
     <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -25,7 +25,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="19" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="94" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="95" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="5" />


### PR DESCRIPTION
this introduces a few changes and prepares the next release
- channels are valid assets now
- technology handling got aligned
- more control over report granularity